### PR TITLE
Add new bindings for P4est-v2.8.0+0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ P4est_jll_bindings is licensed under the MIT license (see [LICENSE.md](LICENSE.m
 Please add new release at the top, i.e., the list is sorted by decreasing
 version number.
 
+* **P4est-v2.8.0+0-v2**
+  ```toml
+  [libp4est]
+  git-tree-sha1 = "3f5d810564ee7aa8f388d206123c891e97e65c65"
+  
+      [[libp4est.download]]
+      sha256 = "af48410539e41c990300966c22d4012a94d5ac0f05045091687803eaef9d381b"
+      url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.8.0+0-v2/P4est.v2.8.0.tar.gz"
+  ```
+
 * **P4est-v2.8.0+0**
   ```toml
   [libp4est]


### PR DESCRIPTION
New pre-generated bindings are required to make the changes proposed in https://github.com/trixi-framework/P4est.jl/pull/48 available when using P4est.jl with the default config.

The tar file with the generated bindings is [P4est.v2.8.0.tar.gz](https://github.com/trixi-framework/P4est_jll_bindings/files/8479377/P4est.v2.8.0.tar.gz).

Since the new bindings are based on the same JLL package as the previously released bindings, the release name would be the same if we followed the conventions outlined in the README. Therefore – based on a suggestion by @sloede – I am using P4est-v2.8.0+0-v2 as the release name in this PR. @ranocha, please tell me if you are ok with this or have another suggestion on how to deal with this.

